### PR TITLE
Turn on react_app_banner_enabled for dev and uat

### DIFF
--- a/azure-devops/core/99_locals.tf
+++ b/azure-devops/core/99_locals.tf
@@ -103,7 +103,7 @@ locals {
     dev_react_app_url_api_dashboard            = "https://api.dev.selfcare.pagopa.it/dashboard/v1"
     dev_react_app_url_api_onboarding           = "https://api.dev.selfcare.pagopa.it/onboarding/v1"
     dev_react_app_url_api_notification         = "https://api.dev.selfcare.pagopa.it/ms-notification-manager"
-    dev_react_app_banner_enabled               = "false"
+    dev_react_app_banner_enabled               = "true"
 
     uat_react_app_url_cdn                      = "https://uat.selfcare.pagopa.it"
     uat_react_app_url_storage                  = "https://selcucheckoutsa.z6.web.core.windows.net"
@@ -125,7 +125,7 @@ locals {
     uat_react_app_url_api_dashboard            = "https://api.uat.selfcare.pagopa.it/dashboard/v1"
     uat_react_app_url_api_onboarding           = "https://api.uat.selfcare.pagopa.it/onboarding/v1"
     uat_react_app_url_api_notification         = "https://api.uat.selfcare.pagopa.it/ms-notification-manager"
-    uat_react_app_banner_enabled               = "false"
+    uat_react_app_banner_enabled               = "true"
 
     prod_react_app_url_cdn                      = "https://selfcare.pagopa.it"
     prod_react_app_url_storage                  = "https://selcpcheckoutsa.z6.web.core.windows.net"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Turned on react_app_banner_enabled for dev and uat

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The value of the environment variable for the dev and uat environments has been changed to true so as to show an alert for possible post-migration disruption

### Type of changes

- [ ] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
