### PR TITLE
The react_app_banner_enabled env variable is turned on for prod and all pnpg env

### DIFF
--- a/azure-devops/core/99_locals.tf
+++ b/azure-devops/core/99_locals.tf
@@ -147,7 +147,7 @@ locals {
     prod_react_app_url_api_dashboard            = "https://api.selfcare.pagopa.it/dashboard/v1"
     prod_react_app_url_api_onboarding           = "https://api.selfcare.pagopa.it/onboarding/v1"
     prod_react_app_url_api_notification         = "https://api.selfcare.pagopa.it/ms-notification-manager"
-    prod_react_app_banner_enabled               = "false"
+    prod_react_app_banner_enabled               = "true"
   }
 
   selc-be-common-variables_deploy = {

--- a/azure-devops/pnpg/99_locals.tf
+++ b/azure-devops/pnpg/99_locals.tf
@@ -78,7 +78,7 @@ locals {
     dev_react_app_url_api_dashboard            = "https://api-pnpg.dev.selfcare.pagopa.it/dashboard/v1"
     dev_react_app_url_api_onboarding           = "https://api-pnpg.dev.selfcare.pagopa.it/onboarding/v1"
     dev_react_app_url_api_notification         = "https://api-pnpg.dev.selfcare.pagopa.it/ms-notification-manager"
-    dev_react_app_banner_enabled               = "false"
+    dev_react_app_banner_enabled               = "true"
     
     uat_react_app_url_cdn                      = "https://imprese.uat.notifichedigitali.it"
     uat_react_app_url_storage                  = "https://selcuweupnpgcheckoutsa.z6.web.core.windows.net"
@@ -100,7 +100,7 @@ locals {
     uat_react_app_url_api_dashboard            = "https://api-pnpg.uat.selfcare.pagopa.it/dashboard/v1"
     uat_react_app_url_api_onboarding           = "https://api-pnpg.uat.selfcare.pagopa.it/onboarding/v1"
     uat_react_app_url_api_notification         = "https://api-pnpg.uat.selfcare.pagopa.it/ms-notification-manager"
-    uat_react_app_banner_enabled               = "false"
+    uat_react_app_banner_enabled               = "true"
 
     prod_react_app_url_cdn                      = "https://imprese.notifichedigitali.it"
     prod_react_app_url_storage                  = "https://selcpweupnpgcheckoutsa.z6.web.core.windows.net"
@@ -122,7 +122,7 @@ locals {
     prod_react_app_url_api_dashboard            = "https://api-pnpg.selfcare.pagopa.it/dashboard/v1"
     prod_react_app_url_api_onboarding           = "https://api-pnpg.selfcare.pagopa.it/onboarding/v1"
     prod_react_app_url_api_notification         = "https://api-pnpg.selfcare.pagopa.it/ms-notification-manager"
-    prod_react_app_banner_enabled               = "false"
+    prod_react_app_banner_enabled               = "true"
   }
 
   pnpg-be-common-variables_deploy = {


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Turned on the react_app_banner_enabled for prod and all pnpg environments

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to show alert banner for possibile disservice caused by v3 migration

### Type of changes

- [ ] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
