### PR TITLE
[SELC-2868] feat: Remove /v2 from onboarding_v2 env var

### DIFF
--- a/azure-devops/core/99_locals.tf
+++ b/azure-devops/core/99_locals.tf
@@ -138,7 +138,7 @@ locals {
     uat_react_app_url_api_party_registry_proxy = "https://api.uat.selfcare.pagopa.it/party-registry-proxy/v1"
     uat_react_app_url_api_dashboard            = "https://api.uat.selfcare.pagopa.it/dashboard/v1"
     uat_react_app_url_api_onboarding           = "https://api.uat.selfcare.pagopa.it/onboarding/v1"
-    uat_react_app_url_api_onboarding_v2        = "https://api.uat.selfcare.pagopa.it/onboarding"
+    uat_react_app_url_api_onboarding_v2        = "https://api.uat.selfcare.pagopa.it/onboarding/v1"
     uat_react_app_url_api_notification         = "https://api.uat.selfcare.pagopa.it/ms-notification-manager"
 
     prod_react_app_url_cdn                      = "https://selfcare.pagopa.it"
@@ -167,7 +167,7 @@ locals {
     prod_react_app_url_api_party_registry_proxy = "https://api.selfcare.pagopa.it/party-registry-proxy/v1"
     prod_react_app_url_api_dashboard            = "https://api.selfcare.pagopa.it/dashboard/v1"
     prod_react_app_url_api_onboarding           = "https://api.selfcare.pagopa.it/onboarding/v1"
-    prod_react_app_url_api_onboarding_v2        = "https://api.selfcare.pagopa.it/onboarding"
+    prod_react_app_url_api_onboarding_v2        = "https://api.selfcare.pagopa.it/onboarding/v1"
     prod_react_app_url_api_notification         = "https://api.selfcare.pagopa.it/ms-notification-manager"
   }
 

--- a/azure-devops/core/99_locals.tf
+++ b/azure-devops/core/99_locals.tf
@@ -109,7 +109,7 @@ locals {
     dev_react_app_url_api_party_registry_proxy = "https://api.dev.selfcare.pagopa.it/party-registry-proxy/v1"
     dev_react_app_url_api_dashboard            = "https://api.dev.selfcare.pagopa.it/dashboard/v1"
     dev_react_app_url_api_onboarding           = "https://api.dev.selfcare.pagopa.it/onboarding/v1"
-    dev_react_app_url_api_onboarding_v2        = "https://api.dev.selfcare.pagopa.it/onboarding/v2"
+    dev_react_app_url_api_onboarding_v2        = "https://api.dev.selfcare.pagopa.it/onboarding"
     dev_react_app_url_api_notification         = "https://api.dev.selfcare.pagopa.it/ms-notification-manager"
 
     uat_react_app_url_cdn                      = "https://uat.selfcare.pagopa.it"
@@ -138,7 +138,7 @@ locals {
     uat_react_app_url_api_party_registry_proxy = "https://api.uat.selfcare.pagopa.it/party-registry-proxy/v1"
     uat_react_app_url_api_dashboard            = "https://api.uat.selfcare.pagopa.it/dashboard/v1"
     uat_react_app_url_api_onboarding           = "https://api.uat.selfcare.pagopa.it/onboarding/v1"
-    uat_react_app_url_api_onboarding_v2        = "https://api.uat.selfcare.pagopa.it/onboarding/v2"
+    uat_react_app_url_api_onboarding_v2        = "https://api.uat.selfcare.pagopa.it/onboarding"
     uat_react_app_url_api_notification         = "https://api.uat.selfcare.pagopa.it/ms-notification-manager"
 
     prod_react_app_url_cdn                      = "https://selfcare.pagopa.it"
@@ -167,7 +167,7 @@ locals {
     prod_react_app_url_api_party_registry_proxy = "https://api.selfcare.pagopa.it/party-registry-proxy/v1"
     prod_react_app_url_api_dashboard            = "https://api.selfcare.pagopa.it/dashboard/v1"
     prod_react_app_url_api_onboarding           = "https://api.selfcare.pagopa.it/onboarding/v1"
-    prod_react_app_url_api_onboarding_v2        = "https://api.selfcare.pagopa.it/onboarding/v2"
+    prod_react_app_url_api_onboarding_v2        = "https://api.selfcare.pagopa.it/onboarding"
     prod_react_app_url_api_notification         = "https://api.selfcare.pagopa.it/ms-notification-manager"
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Removed /v2 from the base url in the oreact_app_url_api_onboarding_v2 env variable.
Change react_app_url_api_onboarding_v2 For PROD and UAT aim at old onboarding path until test in dev are  done.
<!--- Describe your changes in detail -->

### Motivation and context
As this base url need to be dynamic we removed the /v2 from the base url and to be added from the FE
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
