### PR TITLE
Enable user v2 in uat for selfcare and pnpg

### DIFF
--- a/azure-devops/core/99_locals.tf
+++ b/azure-devops/core/99_locals.tf
@@ -147,7 +147,7 @@ locals {
     uat_react_app_url_fe_onboarding-pnpg       = "https://uat.selfcare.pagopa.it/onboarding-pnpg"
     uat_react_app_url_fe_dashboard_admin       = "https://uat.selfcare.pagopa.it/microcomponents/dashboard/admin"
     uat_react_app_url_fe_dashboard_users       = "https://uat.selfcare.pagopa.it/microcomponents/dashboard/users"
-    uat_react_app_enable_user_v2               = "false"
+    uat_react_app_enable_user_v2               = "true"
     uat_react_app_url_fe_dashboard_groups      = "https://uat.selfcare.pagopa.it/microcomponents/dashboard/groups"
     uat_react_app_url_fe_assistance            = "https://uat.selfcare.pagopa.it/assistenza"
     uat_react_app_url_fe_landing               = "https://uat.selfcare.pagopa.it/auth/logout" // TODO when the landing will exists, replace this with the correct URL

--- a/azure-devops/pnpg/99_locals.tf
+++ b/azure-devops/pnpg/99_locals.tf
@@ -99,7 +99,7 @@ locals {
     uat_react_app_url_fe_onboarding-pnpg       = "https://imprese.uat.notifichedigitali.it/onboarding-pnpg"
     uat_react_app_url_fe_dashboard_admin       = "https://imprese.uat.notifichedigitali.it/microcomponents/dashboard/admin"
     uat_react_app_url_fe_dashboard_users       = "https://imprese.uat.notifichedigitali.it/microcomponents/dashboard/users"
-    uat_react_app_enable_user_v2               = "false"
+    uat_react_app_enable_user_v2               = "true"
     uat_react_app_url_fe_dashboard_groups      = "https://imprese.uat.notifichedigitali.it/microcomponents/dashboard/groups"
     uat_react_app_url_fe_assistance            = "https://imprese.uat.notifichedigitali.it/assistenza"
     uat_react_app_url_fe_landing               = "https://imprese.uat.notifichedigitali.it/auth/logout" // TODO when the landing will exists, replace this with the correct URL

--- a/azure-devops/pnpg/99_locals.tf
+++ b/azure-devops/pnpg/99_locals.tf
@@ -72,7 +72,7 @@ locals {
     dev_react_app_url_fe_dashboard             = "https://pnpg.dev.selfcare.pagopa.it/dashboard"
     dev_react_app_url_fe_dashboard_admin       = "https://pnpg.dev.selfcare.pagopa.it/microcomponents/dashboard/admin"
     dev_react_app_url_fe_dashboard_users       = "https://pnpg.dev.selfcare.pagopa.it/microcomponents/dashboard/users"
-    dev_react_app_enable_user_v2               = "false"
+    dev_react_app_enable_user_v2               = "true"
     dev_react_app_url_fe_dashboard_groups      = "https://pnpg.dev.selfcare.pagopa.it/microcomponents/dashboard/groups"
     dev_react_app_url_fe_assistance            = "https://pnpg.dev.selfcare.pagopa.it/assistenza"
     dev_react_app_url_fe_landing               = "https://pnpg.dev.selfcare.pagopa.it/auth/logout" // TODO when the landing will exists, replace this with the correct URL


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Switch env var uat_react_app_enable_user_v2 to true for selfcare
Switch env var uat_react_app_enable_user_v2 to true for selfcare
<!--- Describe your changes in detail -->

### Motivation and context
In order to allow testing in uat enviroment of user
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [ ] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
